### PR TITLE
fix: save updated status in user defaults

### DIFF
--- a/Sources/TwilioEngage/TwilioEngage.swift
+++ b/Sources/TwilioEngage/TwilioEngage.swift
@@ -44,6 +44,7 @@ public class TwilioEngage: EventPlugin {
             return status
         }
         set(value) {
+            userDefaults?.set(value.rawValue, forKey: "Status")
             if self.status != value, let callback = statusCallback {
                 callback(self.status, value)
             }


### PR DESCRIPTION
- saves `status` to `userDefaults` so correct `status` is reflected in track events 